### PR TITLE
feat(312): support adding comment in test run request

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,5 +151,9 @@ await vrt.track({
       height: 400;
     }
   ]
+
+  // Allow additional details
+  // Optional
+  comment: 'Ignoring region because of animation'
 });
 ```

--- a/lib/helpers/dto.helper.ts
+++ b/lib/helpers/dto.helper.ts
@@ -20,6 +20,7 @@ export const multipartDtoToFormData = (dto: TestRunMultipartDto): FormData => {
     data.append("ignoreAreas", JSON.stringify(dto.ignoreAreas));
   dto.diffTollerancePercent &&
     data.append("diffTollerancePercent", dto.diffTollerancePercent);
+  dto.comment && data.append("comment", dto.comment);
 
   return data;
 };
@@ -40,6 +41,7 @@ export const bufferDtoToFormData = (dto: TestRunBufferDto): FormData => {
     data.append("ignoreAreas", JSON.stringify(dto.ignoreAreas));
   dto.diffTollerancePercent &&
     data.append("diffTollerancePercent", dto.diffTollerancePercent);
+  dto.comment && data.append("comment", dto.comment);
 
   return data;
 };

--- a/lib/types/request/testRun.dto.ts
+++ b/lib/types/request/testRun.dto.ts
@@ -24,4 +24,6 @@ export interface TestRunDto {
   merge?: boolean;
 
   ignoreAreas?: IgnoreArea[];
+
+  comment?: string;
 }

--- a/lib/types/testRun.ts
+++ b/lib/types/testRun.ts
@@ -9,6 +9,7 @@ interface TestRun {
   customTags?: string;
   diffTollerancePercent?: number;
   ignoreAreas?: IgnoreArea[];
+  comment?: string;
 }
 
 export interface TestRunBase64 extends TestRun {

--- a/lib/visualRegressionTracker.spec.ts
+++ b/lib/visualRegressionTracker.spec.ts
@@ -142,6 +142,7 @@ const testRunMultipart: TestRunMultipart = {
       width: 400,
     },
   ],
+  comment: "comment",
 };
 
 const testRunBuffer: TestRunBuffer = {
@@ -160,6 +161,7 @@ const testRunBuffer: TestRunBuffer = {
       width: 400,
     },
   ],
+  comment: "comment",
 };
 
 const testRunResponse: TestRunResponse = {


### PR DESCRIPTION
Relates to [#312](https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/312)

Adding comment support for test runs as an optional property.