### PR TITLE
feat: Send "Authorization" header with requests to the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ const config: Config = {
   // Unique ID related to one CI build
   // Optional - default null
   ciBuildId: "SOME_UNIQUE_ID",
+
+  // Value for HTTP "Authorization" header to be used with HTTP requests to the backend
+  // Optional - not sent by default 
+  authHeader: "Basic SECRET"
 };
 ```
 
@@ -66,7 +70,8 @@ _Is overriden if ENV variables are present_
   "apiKey": "tXZVHX0EA4YQM1MGDD",
   "ciBuildId": "commit_sha",
   "branchName": "develop",
-  "enableSoftAssert": false
+  "enableSoftAssert": false,
+  "authHeader": "Basic SECRET"
 }
 ```
 
@@ -81,6 +86,7 @@ VRT_APIKEY="tXZVHX0EA4YQM1MGDD"
 VRT_CIBUILDID="commit_sha"
 VRT_BRANCHNAME="develop"
 VRT_ENABLESOFTASSERT=true
+VRT_AUTH_HEADER="Basic SECRET"
 ```
 
 ### Setup

--- a/lib/helpers/config.helper.ts
+++ b/lib/helpers/config.helper.ts
@@ -27,6 +27,9 @@ const readConfigFromFile = (config: Config): Config => {
     if (fileConfig.enableSoftAssert !== undefined) {
       config.enableSoftAssert = fileConfig.enableSoftAssert;
     }
+    if (fileConfig.authHeader !== undefined) {
+      config.authHeader = fileConfig.authHeader;
+    }
   }
   return config;
 };
@@ -52,6 +55,9 @@ const readConfigFromEnv = (config: Config): Config => {
   }
   if (process.env["VRT_ENABLESOFTASSERT"] !== undefined) {
     config.enableSoftAssert = process.env["VRT_ENABLESOFTASSERT"] === "true";
+  }
+  if (process.env["VRT_AUTH_HEADER"] !== undefined) {
+    config.authHeader = process.env["VRT_AUTH_HEADER"];
   }
   return config;
 };

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -6,4 +6,5 @@ export interface Config extends Record<string, any> {
   apiKey: string;
   enableSoftAssert?: boolean;
   ciBuildId?: string;
+  authHeader?: string;
 }

--- a/lib/visualRegressionTracker.ts
+++ b/lib/visualRegressionTracker.ts
@@ -46,6 +46,7 @@ export class VisualRegressionTracker {
       headers: {
         apiKey: this.config.apiKey,
         project: this.config.project,
+        ...(this.config.authHeader ? { Authorization: this.config.authHeader } : {})
       },
     };
   }


### PR DESCRIPTION
Add optional "authHeader" setting / "VRT_AUTH_HEADER" env variable. Its value will be sent with all requests to the backend. This allows the backend not to be publicly available.

Resolves issue #262.